### PR TITLE
Add SKipper App in Software section

### DIFF
--- a/content/en/docs/software/_index.md
+++ b/content/en/docs/software/_index.md
@@ -13,6 +13,7 @@ Documentation for each software component is provided by their respective projec
 - Signal K: [Signal K Documentation](https://signalk.org/)
 - AvNav: [AvNav Documentation](https://wellenvogel.net/software/avnav/docs/beschreibung.html?lang=en)
 - OpenCPN: [OpenCPN Documentation](https://opencpn.org/)
+- SKipper: [SKipper App](https://www.skipperapp.net/)
 
 Hat Labs provides some additional documentation relevant to common use cases of HALPI computers.
 


### PR DESCRIPTION
Hi Matti,

if you don't mind I would be glad if you could add my new project called "SKipper" on list of your software. What's SKipper? It's versatile dashboard software for Signal K running everywhere (Linux, MacOS, Windows, IPhone, Android and browser - experimental). 

You can read more about SKipper is here: https://docs.skipperapp.net/

Also I would like to ask you about possible terms to have SKipper installed in your HAL PI image by default?

Thank you!
Jan